### PR TITLE
fix: 로깅시 토큰이 없으면 null 예외가 발생하던 버그 수정

### DIFF
--- a/API-Gateway/src/main/java/com/spring/api/filter/LogFilter.java
+++ b/API-Gateway/src/main/java/com/spring/api/filter/LogFilter.java
@@ -91,7 +91,7 @@ public class LogFilter implements WebFilter {
     	
     	String logMemberIP = isa!=null?isa.getAddress().toString():null;
     	String logMemberPort = isa!=null?isa.getPort()+"":null;
-    	String memberAccessToken = !list.isEmpty()?list.getFirst():null;
+    	String memberAccessToken = list!=null&&!list.isEmpty()?list.getFirst():null;
     	String memberID = memberAccessToken!=null?tokenUtil.getMemberIDWithDecoding(memberAccessToken):null;
     	String logParameter = null;
     	


### PR DESCRIPTION
1. 요청을 로깅할 때 토큰이 없으면 null 예외가 발생하던 버그를 수정했습니다.