### PR TITLE
fix: 토스트 메세지 옵션 버그 수정, 잘못된 리다이렉팅 URI 수정

### DIFF
--- a/View-Service/src/main/resources/static/css/modal.css
+++ b/View-Service/src/main/resources/static/css/modal.css
@@ -37,11 +37,11 @@
 /* 실패 */
 
 .toast-wrapper.fail{
-	background-color:rgba(240, 87, 95,0.15);
+	background-color:#fde6e7;
 }
 
 .toast-wrapper.fail .bar{
-	stroke:rgba(240, 87, 95, 1);
+	stroke:rgb(240, 87, 95);
 }
 
 .toast-wrapper.fail .toast-image, .toast-wrapper.fail .toast-close-button-svg{
@@ -55,11 +55,11 @@
 /* 성공 */
 
 .toast-wrapper.success{
-	background-color:rgba(93,149,40,0.15);
+	background-color:#e7efdf;
 }
 
 .toast-wrapper.success .bar{
-	stroke:rgba(93,149,40,1);
+	stroke:rgb(93,149,40);
 }
 
 .toast-wrapper.success .toast-image, .toast-wrapper.success .toast-close-button-svg{
@@ -73,11 +73,11 @@
 /* 알림 */
 
 .toast-wrapper.info{
-	background-color:rgba(0,89,165,0.15);
+	background-color:#d9e6f2;
 }
 
 .toast-wrapper.info .bar{
-	stroke:rgba(0,89,165, 1);
+	stroke:rgb(0,89,165);
 }
 
 .toast-wrapper.info .toast-image, .toast-wrapper.info .toast-close-button-svg{
@@ -90,11 +90,11 @@
 /* 경고 */
 
 .toast-wrapper.alert{
-	background-color:rgba(242,145,0,0.15);
+	background-color:#fdefd9;
 }
 
 .toast-wrapper.alert .bar{
-	stroke:rgba(242,145,0, 1);
+	stroke:rgb(242,145,0);
 }
 
 .toast-wrapper.alert .toast-image, .toast-wrapper.alert .toast-close-button-svg{

--- a/View-Service/src/main/resources/static/js/create-books.js
+++ b/View-Service/src/main/resources/static/js/create-books.js
@@ -159,7 +159,7 @@ jQuery(function(){
 				"book-status":"NORMAL"
 			})
 		}).done(function(response){
-			location.href=API_GATEWAY+"/api/v1/views/board";
+			location.href=API_GATEWAY+"/api/v1/views/read/books";
 		}).fail(function(xhr, status, error){
 			var data = JSON.parse(xhr.responseText);
 			const code = data.code;

--- a/View-Service/src/main/resources/static/js/create-members.js
+++ b/View-Service/src/main/resources/static/js/create-members.js
@@ -90,7 +90,7 @@ jQuery(function(){
 			"contentType":"application/json"
 		}).done(function(response){
 			openToast({
-				"toast-type":"fail",
+				"toast-type":"success",
 				"toast-message":"해당 이메일에 대한 소유권 인증에 성공했습니다. 이메일에 대한 인증정보는 30분간 유효합니다."
 			})
 		}).fail(function(xhr, status, error){


### PR DESCRIPTION
1. 회원 가입 절차에서 이메일 인증에 성공했을 때, 토스트 메세지가 success가 아닌 fail로 나타나던 버그를 수정했습니다.

2. 도서 등록 절차에서, 도서 등록에 성공했을 때 리다이렉팅 될 URI가 /views/board가 아니라 /views/read/books가 되도록 수정했습니다.